### PR TITLE
Remove argument from newEditEntity() call

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -211,7 +211,7 @@ class NimiarkistoImport extends Maintenance {
 	}
 
 	private function saveEntity( EntityDocument $entity, $textSummary ) {
-		$editEntity = $this->editEntityFactory->newEditEntity( $this->user, $entity->getId(), false );
+		$editEntity = $this->editEntityFactory->newEditEntity( $this->user, $entity->getId() );
 		return $editEntity->attemptSave( $entity, $textSummary, 0, false );
 	}
 }


### PR DESCRIPTION
This has been the default behavior for years, and we’re about to make the parameter int-only (false and true both mean the same as 0) in [Gerrit change I9a9f9e1cc7](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/908350).