### PR TITLE
Change Mediawiki* class reference to MediaWiki*

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -22,7 +22,7 @@ use Wikibase\DataModel\Snak\PropertyNoValueSnak;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Statement\StatementList;
 use Wikibase\DataModel\Term\Fingerprint;
-use Wikibase\Repo\EditEntity\MediawikiEditEntityFactory;
+use Wikibase\Repo\EditEntity\MediaWikiEditEntityFactory;
 use Wikibase\Repo\WikibaseRepo;
 
 require __DIR__ . '/vendor/autoload.php';
@@ -36,7 +36,7 @@ class NimiarkistoImport extends Maintenance {
 	private $user;
 	/** @var array */
 	private $data;
-	/** @var MediawikiEditEntityFactory */
+	/** @var MediaWikiEditEntityFactory */
 	private $editEntityFactory;
 	/** @var GuidGenerator */
 	private $guidGenerator;


### PR DESCRIPTION
The class is being renamed in [Wikibase change Ia9ac1f4382](https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Wikibase/+/932259). (Because class names are case-insensitive in PHP, this change can actually be merged either before or after that change, it’ll work either way.)

----

Totally optional, but should work even in MediaWiki 1.35 (since you mentioned in #22 that the script is outdated anyway).